### PR TITLE
Add `mailto:` to valid protocols list

### DIFF
--- a/wikidataintegrator/wdi_core.py
+++ b/wikidataintegrator/wdi_core.py
@@ -2078,7 +2078,7 @@ class WDUrl(WDBaseDataType):
         if value is None:
             self.value = None
         else:
-            protocols = ['http://', 'https://', 'ftp://', 'irc://']
+            protocols = ['http://', 'https://', 'ftp://', 'irc://', 'mailto:']
             if True not in [True for x in protocols if value.startswith(x)]:
                 raise ValueError('Invalid URL')
 


### PR DESCRIPTION
Hello, I was trying to harness WikidataIntegrator for building a bot for a datasets loading when I noticed an unexpected behavior of this library.

### Description of the problem
When you try to get items with an [email property](https://www.wikidata.org/wiki/Property:P968) a `ValueError` is returned.

#### Example

data (complete item [here](https://www.wikidata.org/wiki/Q52083858)): 
```ttl
wd:Q52083858 wdt:P968 'mailto:BLIC816001@istruzione.it'
```
unexpected behavior:

```Python
>>> my_first_wikidata_item = wdi_core.WDItemEngine(wd_item_id='Q52083858')
ValueError: Invalid URL
```
### PR

Seems like `mailto:` is not considered a valid protocol. I added that to the protocols list. I hope this is fine with the lib logics. Working example below:

```Python
>>> my_first_wikidata_item = wdi_core.WDItemEngine(wd_item_id='Q52083858')
>>> my_first_wikidata_item.get_wd_json_representation()
{'aliases': {},
 'claims': {'P131': [{'id': 'Q52083858$28D649E8-4A31-43DC-8EAE-61E531D5BD40',
    'mainsnak': {'datatype': 'wikibase-item',
     'datavalue': {'type': 'wikibase-entityid',
      'value': {'entity-type': 'item', 'id': 'Q40323', 'numeric-id': 40323}},
     'property': 'P131',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}],
  'P17': [{'id': 'Q52083858$93D3D338-0BB0-4FEE-B147-6CCD4B7DCA14',
    'mainsnak': {'datatype': 'wikibase-item',
     'datavalue': {'type': 'wikibase-entityid',
      'value': {'entity-type': 'item', 'id': 'Q38', 'numeric-id': 38}},
     'property': 'P17',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}],
  'P281': [{'id': 'Q52083858$145B96ED-9D05-4E6F-9FA3-FC3C9E12493F',
    'mainsnak': {'datatype': 'string',
     'datavalue': {'type': 'string', 'value': '32020'},
     'property': 'P281',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}],
  'P31': [{'id': 'Q52083858$2A24CFA9-907C-437F-8445-B926EB2290C7',
    'mainsnak': {'datatype': 'wikibase-item',
     'datavalue': {'type': 'wikibase-entityid',
      'value': {'entity-type': 'item', 'id': 'Q9842', 'numeric-id': 9842}},
     'property': 'P31',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}],
  'P968': [{'id': 'Q52083858$52A99E2C-1F84-4541-980B-282EAA17842E',
    'mainsnak': {'datatype': 'url',
     'datavalue': {'type': 'string',
      'value': 'mailto:BLIC816001@istruzione.it'},
     'property': 'P968',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}],
  'P969': [{'id': 'Q52083858$E1668AC9-14EE-4753-A9AD-52AE07F4EFF3',
    'mainsnak': {'datatype': 'string',
     'datavalue': {'type': 'string', 'value': 'Via Tofane 1, 32020 Limana'},
     'property': 'P969',
     'snaktype': 'value'},
    'qualifiers': {},
    'qualifiers-order': [],
    'rank': 'normal',
    'references': [{'hash': '19ebf63b0fce9dee6b8ea14ecb830dbec364dec6',
      'snaks': {'P248': [{'datatype': 'wikibase-item',
         'datavalue': {'type': 'wikibase-entityid',
          'value': {'entity-type': 'item',
           'id': 'Q52116343',
           'numeric-id': 52116343}},
         'property': 'P248',
         'snaktype': 'value'}],
       'P813': [{'datatype': 'time',
         'datavalue': {'type': 'time',
          'value': {'after': 0,
           'before': 0,
           'calendarmodel': 'http://www.wikidata.org/entity/Q1985727',
           'precision': 11,
           'time': '+2018-04-20T00:00:00Z',
           'timezone': 0}},
         'property': 'P813',
         'snaktype': 'value'}],
       'P854': [{'datatype': 'url',
         'datavalue': {'type': 'string',
          'value': 'http://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole'},
         'property': 'P854',
         'snaktype': 'value'}]},
      'snaks-order': ['P248', 'P854', 'P813']}],
    'type': 'statement'}]},
 'descriptions': {'en': {'language': 'en',
   'value': 'Primary School in Limana in the province of Belluno (Italy)'},
  'it': {'language': 'it',
   'value': 'Scuola Primo Grado di Limana in provinica di Belluno (Italia)'}},
 'labels': {'en': {'language': 'en', 'value': 'D. Buzzati Limana'},
  'it': {'language': 'it', 'value': 'D. Buzzati Limana'}},
 'sitelinks': {}}
```

Thank for putting so much effort in this project! Bye,

^..^