### PR TITLE
Improvements in wbs_core

### DIFF
--- a/wikidataintegrator/tests/data/test_schema.shex
+++ b/wikidataintegrator/tests/data/test_schema.shex
@@ -1,232 +1,35 @@
-# E108: genome_assembly
-IMPORT <https://www.wikidata.org/wiki/Special:EntitySchemaText/E108>
-PREFIX E108: <https://www.wikidata.org/wiki/Special:EntitySchemaText/E108#>
-
-# E109: human chromosome
-IMPORT <https://www.wikidata.org/wiki/Special:EntitySchemaText/E109>
-PREFIX E109: <https://www.wikidata.org/wiki/Special:EntitySchemaText/E109#>
-
-# Shape Expression for Human genes in Wikidata
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX p: <http://www.wikidata.org/prop/>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX prv: <http://www.wikidata.org/prop/reference/value/>
-PREFIX pr:  <http://www.wikidata.org/prop/reference/>
-PREFIX ps: <http://www.wikidata.org/prop/statement/>
 
-BASE <http://www.wikidata.org/entity/>
+start = @<human>
 
-start = @<#wikidata-human-gene>
-
-# Query with results
-# SELECT * WHERE {?item wdt:P31 wd:Q7187 ; wdt:P703 wd:Q15978631 .} LIMIT 10
-
-# Indicates which shape to use to start iterating over the graph if none is provided.
-
-# wikidata-human gene is the main shape for a human gene data model in Wikidata. Each line between the brackets
-# represents the structure than can be enforced to validate human gene annotations in Wikidata
-#
-# We distinguish between value statements, identifier statements, and erroneous statements.
-# Value statements contain either actual values, or pointers to other Wikidata items. Identifier statements capture
-# external identifiers, erroneous statements are those that are errors.
-#
-
-<#wikidata-human-gene> EXTRA p:P31  {
-
-    # below is a special shape used to express that both the genomic start and genomic end properties are not mandatory
-    # however if one does exist, the other one is required. The * behind the brackets indicates the 0 or more cardinality
-    # that expresses the requirement that both properties are not mandatory.
-	p:P31 @<#P31_instance_of_gene> ;
-        (
-		p:P644 @<#P644_genomic_start> ; # Its genomic start location
-		p:P645 @<#P645_genomic_end> ; # Its genomic end location
-	)* ; # Zero or more start and end locations.
-
-	p:P684 @<#P684_ortholog>* ; # Zero or more known orthologs.
-	p:P688 @<#P688_encodes>* ; # Zero or more known geneproducts.
-	p:P703 @<#P703_found_in_taxon_human> ; # In which taxonomy and where in that taxonomy this gene is found
-	p:P1057 @<#P1057_chromosome>* ;  # Zero or more known chromosomes the gene is located on.
-	p:P2888 . ; # @<#P2888_exact_match>+ ; # One or more external Internationalized Resource Identifiers of a node on the
-	                                # semantic web, describing the same concept as linked data.
-	p:P2548 @<#P2548_strand_orientation> ; # Its strand orrientation
-
-	# IDENTIFIER STATEMENTS
-	p:P351 @<#P351_ncbi_gene_id> ; # Exactly one ncbi gene identifier
-	p:P353 @<#P353_hgnc_gene_symbol> ; # Exactly one hgnc gene symbol
-	p:P354 @<#P354_hgnc_gene_id> ; # Exactly one hgnc gene identifier
-	p:P594 @<#P594_ensembl_gene_id>* ; # Zero or more Ensembl gene identifier
-	p:P639 @<#P639_refseq_rna_id>* ; # Zero or more RefSeq RNA identifiers
-	p:P704 @<#P704_ensembl_transcript_id>* ; # Zero or more Ensembl Transcript identifiers.
-	p:P593 @<#P593_homologene_id> ; # Exactly one homologene identifier
-
-	# Negative shapes
-	p:P352 @<#P352_uniprot_id_wor>{0} ; # A gene can't have a uniprot identifier.
+<human> EXTRA wdt:P31 {
+  wdt:P31 [wd:Q5];
+  wdt:P21 [wd:Q6581097 wd:Q6581072 wd:Q1097630 wd:Q1052281 wd:Q2449503 wd:Q48270]?;   # gender
+  wdt:P19 . ?;                     # place of birth
+  wdt:P569 . ? ;                 # date of birth
+  wdt:P735 . * ;                 # given name
+  wdt:P734 . * ;                 # family name
+  wdt:P106 . * ;                 # occupation
+  wdt:P27 @<country> *;  # country of citizenship
+  wdt:P22 @<human> *;           # father
+  wdt:P25 @<human> *;           # mother
+  wdt:P3373 @<human> *;         # sibling
+  wdt:P26 @<human> *;           # husband/wife
+  wdt:P40 @<human> *;           # children
+  wdt:P1038 @<human> *;         # relatives
+  wdt:P103 @<language> *;
+  wdt:P1412 @<language> *;
+  wdt:P6886  @<language> *;
+  rdfs:label rdf:langString+;
 }
 
-# Detailed ShExs for Wikidata statements
-# Wikidata captures a statement in the following graph pattern:
-####################
-# wd:Pxx wikibase:directClaim wdt:Pxx ;
-#        wikibase:claim p:Pxx .
-# <item> wdt:Pxx "value" or <other_item> .
-# <item> p:Pxx <node> .
-# <node> ps:Pxx "value" or <other_item> ;
-#        pq:Pxx "qualifier value" or <qualifier_item> ;
-#        pr:Pxx "reference value" or <reference_item> .
-####################
-
-<#P31_instance_of_gene> {
-   ps:P31 @<#gene_types> ;     # Instance of [P31] gene types
-   prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
+<country> EXTRA wdt:P31 {
+  wdt:P31 [wd:Q6256 wd:Q3024240 wd:Q3624078] +;
 }
 
-<#P279_subclass_of_gene> {
-    ps:P279 @<#gene_types> ; # Subclass of [P279] gene types <gene_types>
-	prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
+<language> EXTRA wdt:P31 {
+  wdt:P31 [wd:Q34770 wd:Q1288568] +;
 }
-
-<#P644_genomic_start> {
-   ps:P644 LITERAL ;  # genomic start [P644] value
-   pq:P1057	@E109:humanChromosome+ ;	 # Qualifier indicating the applicable chromosome [P1057] from a set of
-                                     #  list Wikidata on chromosomes described below.
-   pq:P659	@E108:sequence_assembly+ ;  # Qualifier indicating the applicable genomic assembly versions.
-   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
-}
-
-<#P645_genomic_end> {
-   ps:P645 LITERAL ; # genomic start [P645] value
-   pq:P1057	@E109:humanChromosome+ ;	 # Qualifier indicating the applicable chromosome [P1057] from a set of
-                                     #  list Wikidata on chromosomes described below.
-   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the applicable genomic assembly versions.
-   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
-}
-
-<#P684_ortholog> {
-   ps:P684 IRI ; # Known orthologs [P684].
-   pq:P703	IRI ; # Qualifier indicating in which taxon the ortholog is found [P703].
-   prov:wasDerivedFrom	@<#homologene-reference> ;
-}
-
-<#P688_encodes> {
-   ps:P688 IRI ; # gene encodes [688] for a gene product.
-   prov:wasDerivedFrom @<#uniprot-reference>;
-}
-
-<#P703_found_in_taxon_human> {
-   ps:P703 [wd:Q15978631] ; # the gene is found in taxon [P703] human [Q15978631]
-   prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
-}
-
-<#P1057_chromosome> {
-   ps:P1057 @E109:humanChromosome ; # gene is found on chromosome [P1057]
-   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the one or more applicable genomic assembly
-   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
-}
-
-<#P2888_exact_match> {
-   ps:P2888 IRI ; # External IRI which describe the exact same concept [P2888]
-   prov:wasDerivedFrom @<#miriam_reference> OR @<#ncbi-gene-reference> ;
-}
-
-<#P2548_strand_orientation> {
-   ps:P2548	@<#strand-orientation> ; # Strand orientation [P2548] of the gene
-   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the one or more applicable genomic assembly
-   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
-}
-
-<#strand-orientation> [ # list of wikidata items for both the reverse and forward strand
-    wd:Q22809711 # reverse strand
-    wd:Q22809680 # forward strand
-]
-
-## IDENTIFIERS
-<#P351_ncbi_gene_id> {
-	ps:P351 LITERAL ; # The NCBI gene identifier [P351] for the applicable gene item.
-	prov:wasDerivedFrom @<#ncbi-gene-reference> ;
-}
-
-<#P352_uniprot_id_wor> { # The (non-existent) uniprot identifier [P352] for the applicable gene item.
-    ps:P352 LITERAL ;
-}
-
-<#P353_hgnc_gene_symbol> {
-   ps:P353 LITERAL ; # The gene symbol [P353] for the applicable gene item.
-   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
-}
-
-<#P354_hgnc_gene_id> {
-   ps:P354 LITERAL ; # The HGNC gene identifier  [P354] for the applicable gene item.
-   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
-}
-
-<#P593_homologene_id> {
-   ps:P593 LITERAL ; # The homologene identifier [P593] for the applicable gene item.
-   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
-}
-
-<#P594_ensembl_gene_id> {
-   ps:P594 LITERAL ; # The Ensembl gene identifier [P594] for the applicable gene item.
-   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
-}
-
-<#P639_refseq_rna_id> {
-   ps:P639 LITERAL ; # The RefSeq RNA identifier [P351] for the applicable gene item.
-   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
-}
-
-<#P704_ensembl_transcript_id> {
-   ps:P704 LITERAL ; # The Ensembl transcript identifier [P704] for the applicable gene item
-   prov:wasDerivedFrom @<#ensembl-gene-reference> OR <#ncbi-gene-reference> ;
-}
-
-## REFERENCES
-<#ncbi-gene-reference> { # reference to a NCBI gene record
-  pr:P248   [ wd:Q20641742 ] ; # stated in [P248] NCBI gene [Q20641742]
-  pr:P351	LITERAL ; # NCBI gene identifier
-  pr:P813	xsd:dateTime ; # Date of retrieval
-}
-
-<#ensembl-gene-reference> {
-  pr:P248	[
-         wd:Q30227110 # stated in [P248] Ensembl Release 89 [Q30227110]
-         wd:Q46401024 # stated in [P248] Ensembl Release 91 [Q30227110]
-         wd:Q57339524 # stated in [P248] Ensembl Release 94 [Q57339524]
-         wd:Q63170780 # stated in [P248] Ensembl Release 96 [Q63170780]
-         wd:Q67600000 # stated in [P248] Ensembl Release 97 [Q67600000]
-         wd:Q71033229 # stated in [P248] Ensembl Release 98 [Q71033229]
-         ] ;
-  pr:P594	LITERAL ; # Ensembl Gene ID [P594]
-}
-
-<#homologene-reference> {
-  pr:P248 [wd:Q20976936]; # Stated in [P248]  homologene build68 [Q20976936]
-  pr:P593 LITERAL; # Homologene identifier
-}
-
-<#miriam_reference> {
-  pr:P248		[wd:Q16335166] ; # Stated in [P248] MIRIAM registry
-  pr:P854		IRI ; # Reference URL [P854] to a IRI
-}
-
-<#uniprot-reference> {
-  pr:P248	[wd:Q905695] ;
-  pr:P352	LITERAL ;
-  pr:P813	xsd:dateTime ;
-}
-
-## Lists with Wikidata items
-<#gene_types> [
-  wd:Q7187  # gene
-  wd:Q20747295 # protein-coding gene
-  wd:Q427087 # ncRNA
-  wd:Q284578 # snRNA
-  wd:Q284416 # snoRNA
-  wd:Q215980 # rRNA
-  wd:Q201448 # tRNA
-  wd:Q277338 # pseudo
-  wd:Q11053 # miscRNA
-  wd:Q25323710 # scRNA
-			 ]

--- a/wikidataintegrator/tests/data/test_schema.shex
+++ b/wikidataintegrator/tests/data/test_schema.shex
@@ -1,0 +1,232 @@
+# E108: genome_assembly
+IMPORT <https://www.wikidata.org/wiki/Special:EntitySchemaText/E108>
+PREFIX E108: <https://www.wikidata.org/wiki/Special:EntitySchemaText/E108#>
+
+# E109: human chromosome
+IMPORT <https://www.wikidata.org/wiki/Special:EntitySchemaText/E109>
+PREFIX E109: <https://www.wikidata.org/wiki/Special:EntitySchemaText/E109#>
+
+# Shape Expression for Human genes in Wikidata
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prv: <http://www.wikidata.org/prop/reference/value/>
+PREFIX pr:  <http://www.wikidata.org/prop/reference/>
+PREFIX ps: <http://www.wikidata.org/prop/statement/>
+
+BASE <http://www.wikidata.org/entity/>
+
+start = @<#wikidata-human-gene>
+
+# Query with results
+# SELECT * WHERE {?item wdt:P31 wd:Q7187 ; wdt:P703 wd:Q15978631 .} LIMIT 10
+
+# Indicates which shape to use to start iterating over the graph if none is provided.
+
+# wikidata-human gene is the main shape for a human gene data model in Wikidata. Each line between the brackets
+# represents the structure than can be enforced to validate human gene annotations in Wikidata
+#
+# We distinguish between value statements, identifier statements, and erroneous statements.
+# Value statements contain either actual values, or pointers to other Wikidata items. Identifier statements capture
+# external identifiers, erroneous statements are those that are errors.
+#
+
+<#wikidata-human-gene> EXTRA p:P31  {
+
+    # below is a special shape used to express that both the genomic start and genomic end properties are not mandatory
+    # however if one does exist, the other one is required. The * behind the brackets indicates the 0 or more cardinality
+    # that expresses the requirement that both properties are not mandatory.
+	p:P31 @<#P31_instance_of_gene> ;
+        (
+		p:P644 @<#P644_genomic_start> ; # Its genomic start location
+		p:P645 @<#P645_genomic_end> ; # Its genomic end location
+	)* ; # Zero or more start and end locations.
+
+	p:P684 @<#P684_ortholog>* ; # Zero or more known orthologs.
+	p:P688 @<#P688_encodes>* ; # Zero or more known geneproducts.
+	p:P703 @<#P703_found_in_taxon_human> ; # In which taxonomy and where in that taxonomy this gene is found
+	p:P1057 @<#P1057_chromosome>* ;  # Zero or more known chromosomes the gene is located on.
+	p:P2888 . ; # @<#P2888_exact_match>+ ; # One or more external Internationalized Resource Identifiers of a node on the
+	                                # semantic web, describing the same concept as linked data.
+	p:P2548 @<#P2548_strand_orientation> ; # Its strand orrientation
+
+	# IDENTIFIER STATEMENTS
+	p:P351 @<#P351_ncbi_gene_id> ; # Exactly one ncbi gene identifier
+	p:P353 @<#P353_hgnc_gene_symbol> ; # Exactly one hgnc gene symbol
+	p:P354 @<#P354_hgnc_gene_id> ; # Exactly one hgnc gene identifier
+	p:P594 @<#P594_ensembl_gene_id>* ; # Zero or more Ensembl gene identifier
+	p:P639 @<#P639_refseq_rna_id>* ; # Zero or more RefSeq RNA identifiers
+	p:P704 @<#P704_ensembl_transcript_id>* ; # Zero or more Ensembl Transcript identifiers.
+	p:P593 @<#P593_homologene_id> ; # Exactly one homologene identifier
+
+	# Negative shapes
+	p:P352 @<#P352_uniprot_id_wor>{0} ; # A gene can't have a uniprot identifier.
+}
+
+# Detailed ShExs for Wikidata statements
+# Wikidata captures a statement in the following graph pattern:
+####################
+# wd:Pxx wikibase:directClaim wdt:Pxx ;
+#        wikibase:claim p:Pxx .
+# <item> wdt:Pxx "value" or <other_item> .
+# <item> p:Pxx <node> .
+# <node> ps:Pxx "value" or <other_item> ;
+#        pq:Pxx "qualifier value" or <qualifier_item> ;
+#        pr:Pxx "reference value" or <reference_item> .
+####################
+
+<#P31_instance_of_gene> {
+   ps:P31 @<#gene_types> ;     # Instance of [P31] gene types
+   prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
+}
+
+<#P279_subclass_of_gene> {
+    ps:P279 @<#gene_types> ; # Subclass of [P279] gene types <gene_types>
+	prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
+}
+
+<#P644_genomic_start> {
+   ps:P644 LITERAL ;  # genomic start [P644] value
+   pq:P1057	@E109:humanChromosome+ ;	 # Qualifier indicating the applicable chromosome [P1057] from a set of
+                                     #  list Wikidata on chromosomes described below.
+   pq:P659	@E108:sequence_assembly+ ;  # Qualifier indicating the applicable genomic assembly versions.
+   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
+}
+
+<#P645_genomic_end> {
+   ps:P645 LITERAL ; # genomic start [P645] value
+   pq:P1057	@E109:humanChromosome+ ;	 # Qualifier indicating the applicable chromosome [P1057] from a set of
+                                     #  list Wikidata on chromosomes described below.
+   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the applicable genomic assembly versions.
+   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
+}
+
+<#P684_ortholog> {
+   ps:P684 IRI ; # Known orthologs [P684].
+   pq:P703	IRI ; # Qualifier indicating in which taxon the ortholog is found [P703].
+   prov:wasDerivedFrom	@<#homologene-reference> ;
+}
+
+<#P688_encodes> {
+   ps:P688 IRI ; # gene encodes [688] for a gene product.
+   prov:wasDerivedFrom @<#uniprot-reference>;
+}
+
+<#P703_found_in_taxon_human> {
+   ps:P703 [wd:Q15978631] ; # the gene is found in taxon [P703] human [Q15978631]
+   prov:wasDerivedFrom @<#ncbi-gene-reference> OR @<#ensembl-gene-reference> ;
+}
+
+<#P1057_chromosome> {
+   ps:P1057 @E109:humanChromosome ; # gene is found on chromosome [P1057]
+   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the one or more applicable genomic assembly
+   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
+}
+
+<#P2888_exact_match> {
+   ps:P2888 IRI ; # External IRI which describe the exact same concept [P2888]
+   prov:wasDerivedFrom @<#miriam_reference> OR @<#ncbi-gene-reference> ;
+}
+
+<#P2548_strand_orientation> {
+   ps:P2548	@<#strand-orientation> ; # Strand orientation [P2548] of the gene
+   pq:P659	@E108:sequence_assembly+ ; # Qualifier indicating the one or more applicable genomic assembly
+   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
+}
+
+<#strand-orientation> [ # list of wikidata items for both the reverse and forward strand
+    wd:Q22809711 # reverse strand
+    wd:Q22809680 # forward strand
+]
+
+## IDENTIFIERS
+<#P351_ncbi_gene_id> {
+	ps:P351 LITERAL ; # The NCBI gene identifier [P351] for the applicable gene item.
+	prov:wasDerivedFrom @<#ncbi-gene-reference> ;
+}
+
+<#P352_uniprot_id_wor> { # The (non-existent) uniprot identifier [P352] for the applicable gene item.
+    ps:P352 LITERAL ;
+}
+
+<#P353_hgnc_gene_symbol> {
+   ps:P353 LITERAL ; # The gene symbol [P353] for the applicable gene item.
+   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
+}
+
+<#P354_hgnc_gene_id> {
+   ps:P354 LITERAL ; # The HGNC gene identifier  [P354] for the applicable gene item.
+   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
+}
+
+<#P593_homologene_id> {
+   ps:P593 LITERAL ; # The homologene identifier [P593] for the applicable gene item.
+   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
+}
+
+<#P594_ensembl_gene_id> {
+   ps:P594 LITERAL ; # The Ensembl gene identifier [P594] for the applicable gene item.
+   prov:wasDerivedFrom @<#ensembl-gene-reference> ;
+}
+
+<#P639_refseq_rna_id> {
+   ps:P639 LITERAL ; # The RefSeq RNA identifier [P351] for the applicable gene item.
+   prov:wasDerivedFrom @<#ncbi-gene-reference> ;
+}
+
+<#P704_ensembl_transcript_id> {
+   ps:P704 LITERAL ; # The Ensembl transcript identifier [P704] for the applicable gene item
+   prov:wasDerivedFrom @<#ensembl-gene-reference> OR <#ncbi-gene-reference> ;
+}
+
+## REFERENCES
+<#ncbi-gene-reference> { # reference to a NCBI gene record
+  pr:P248   [ wd:Q20641742 ] ; # stated in [P248] NCBI gene [Q20641742]
+  pr:P351	LITERAL ; # NCBI gene identifier
+  pr:P813	xsd:dateTime ; # Date of retrieval
+}
+
+<#ensembl-gene-reference> {
+  pr:P248	[
+         wd:Q30227110 # stated in [P248] Ensembl Release 89 [Q30227110]
+         wd:Q46401024 # stated in [P248] Ensembl Release 91 [Q30227110]
+         wd:Q57339524 # stated in [P248] Ensembl Release 94 [Q57339524]
+         wd:Q63170780 # stated in [P248] Ensembl Release 96 [Q63170780]
+         wd:Q67600000 # stated in [P248] Ensembl Release 97 [Q67600000]
+         wd:Q71033229 # stated in [P248] Ensembl Release 98 [Q71033229]
+         ] ;
+  pr:P594	LITERAL ; # Ensembl Gene ID [P594]
+}
+
+<#homologene-reference> {
+  pr:P248 [wd:Q20976936]; # Stated in [P248]  homologene build68 [Q20976936]
+  pr:P593 LITERAL; # Homologene identifier
+}
+
+<#miriam_reference> {
+  pr:P248		[wd:Q16335166] ; # Stated in [P248] MIRIAM registry
+  pr:P854		IRI ; # Reference URL [P854] to a IRI
+}
+
+<#uniprot-reference> {
+  pr:P248	[wd:Q905695] ;
+  pr:P352	LITERAL ;
+  pr:P813	xsd:dateTime ;
+}
+
+## Lists with Wikidata items
+<#gene_types> [
+  wd:Q7187  # gene
+  wd:Q20747295 # protein-coding gene
+  wd:Q427087 # ncRNA
+  wd:Q284578 # snRNA
+  wd:Q284416 # snoRNA
+  wd:Q215980 # rRNA
+  wd:Q201448 # tRNA
+  wd:Q277338 # pseudo
+  wd:Q11053 # miscRNA
+  wd:Q25323710 # scRNA
+			 ]

--- a/wikidataintegrator/tests/test_wbs_core.py
+++ b/wikidataintegrator/tests/test_wbs_core.py
@@ -9,6 +9,7 @@ from wikidataintegrator import wbs_core
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 def mocked_request_properties_once(_):
+    """ Mock a request to get the properties of a wikibase with 2 properties """
     res = mock.Mock()
     res.text = json.dumps({
         "batchcomplete":"",
@@ -22,11 +23,13 @@ def mocked_request_properties_once(_):
     return res
 
 def mocked_request_properties_empty(_):
+    """ Mock a request to get the properties of an empty wikibase """
     res = mock.Mock()
     res.text = json.dumps({"batchcomplete": ""})
     return res
 
 def mocked_request_properties_gapcontinue(_):
+    """ Mock a request to get the properties of a wikibase with many properties """
     res = mock.Mock()
     res.text = json.dumps({
         "batchcomplete":"",
@@ -35,6 +38,22 @@ def mocked_request_properties_gapcontinue(_):
             "pages":{
                 "4":{"pageid":4, "title":"Property:P4", "terms":{"label":["Ensembl transcript ID"]}},
                 "15":{"pageid":15, "title":"Property:P9", "terms":{"label":["chromosome"]}}
+            }
+        }
+    })
+    return res
+
+def mocked_request_namespaces(_):
+    """ Mock a request to receive the namespaces of a mediawiki instance """
+    res = mock.Mock()
+    res.text = json.dumps({
+        "batchcomplete":True,
+        "query": {
+            "namespaces": {
+                "-1":{"id":-1, "case":"first-letter", "name":"Special"},
+                "4":{"id":4, "case":"first-letter", "name":"Project"},
+                "12":{"id":12, "case":"first-letter", "name":"Help"},
+                "122":{"id":122, "case":"first-letter", "name":"Property"}
             }
         }
     })
@@ -72,13 +91,23 @@ class TestWBSCore(unittest.TestCase):
         expected = ["Ensembl transcript ID", "chromosome", "genomic start", "instance of"]
         self.assertListEqual(result, expected)
 
-    def test_get_namespace(self):
-        pass
+    @mock.patch('requests.get', side_effect=mocked_request_namespaces)
+    def test_get_namespace(self, mock_get):
+        wbs_engine = wbs_core.WikibaseEngine('www.example.org')
+        self.assertEqual(wbs_engine.getNamespace("Special"), "-1")
+        self.assertEqual(wbs_engine.getNamespace("Help"), "12")
+        self.assertEqual(wbs_engine.getNamespace("Property"), "122")
+        self.assertEqual(wbs_engine.getNamespace("Invented"), None)
 
     def test_extract_properties(self):
         properties = []
         wbs_core.WikibaseEngine.extractProperties(self.model, properties)
-        expected = []
+        wdt = "http://www.wikidata.org/prop/direct/"
+        rdfs = "http://www.w3.org/2000/01/rdf-schema#"
+        expected = [f"{wdt}P31", f"{wdt}P21", f"{wdt}P19", f"{wdt}P569", f"{wdt}P735",
+                    f"{wdt}P734", f"{wdt}P106", f"{wdt}P27", f"{wdt}P22", f"{wdt}P25",
+                    f"{wdt}P3373", f"{wdt}P26", f"{wdt}P40", f"{wdt}P1038", f"{wdt}P103",
+                    f"{wdt}P1412", f"{wdt}P6886", f"{rdfs}label", f"{wdt}P31", f"{wdt}P31"]
         self.assertListEqual(properties, expected)
 
     def _load_test_shex(self, file_name):

--- a/wikidataintegrator/tests/test_wbs_core.py
+++ b/wikidataintegrator/tests/test_wbs_core.py
@@ -1,0 +1,89 @@
+import json
+import os
+import unittest
+
+from pyshex.utils.schema_loader import SchemaLoader
+from unittest import mock
+from wikidataintegrator import wbs_core
+
+TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+
+def mocked_request_properties_once(_):
+    res = mock.Mock()
+    res.text = json.dumps({
+        "batchcomplete":"",
+        "query":{
+            "pages":{
+                "2":{"pageid":2, "title":"Property:P1", "terms":{"label":["genomic start"]}},
+                "11":{"pageid":11, "title":"Property:P10", "terms":{"label":["instance of"]}}
+            }
+        }
+    })
+    return res
+
+def mocked_request_properties_empty(_):
+    res = mock.Mock()
+    res.text = json.dumps({"batchcomplete": ""})
+    return res
+
+def mocked_request_properties_gapcontinue(_):
+    res = mock.Mock()
+    res.text = json.dumps({
+        "batchcomplete":"",
+        "continue": {"gapcontinue": 'P1', "continue": "gapcontinue||"},
+        "query":{
+            "pages":{
+                "4":{"pageid":4, "title":"Property:P4", "terms":{"label":["Ensembl transcript ID"]}},
+                "15":{"pageid":15, "title":"Property:P9", "terms":{"label":["chromosome"]}}
+            }
+        }
+    })
+    return res
+
+class TestWBSCore(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._load_test_shex('test_schema.shex')
+        self.mocked_wbengine = wbs_core.WikibaseEngine('www.example.org')
+        self.mocked_wbengine.getNamespace = unittest.mock.Mock()
+        self.mocked_wbengine.getNamespace.side_effect = "P5"
+
+    def test_init(self):
+        endpoint = 'http://example.org'
+        wb_engine = wbs_core.WikibaseEngine(endpoint)
+        self.assertEqual(wb_engine.wikibase_url, endpoint)
+        self.assertEqual(wb_engine.wikibase_api, f"{endpoint}/w/api.php")
+
+    @mock.patch('requests.get', side_effect=mocked_request_properties_empty)
+    def test_list_properties_empty(self, mock_get):
+        result = self.mocked_wbengine.listProperties()
+        self.assertListEqual(result, [])
+
+    @mock.patch('requests.get', side_effect=mocked_request_properties_once)
+    def test_list_properties_once(self, mock_get):
+        result = self.mocked_wbengine.listProperties()
+        expected = ["genomic start", "instance of"]
+        self.assertListEqual(result, expected)
+
+    @mock.patch('requests.get', side_effect=[mocked_request_properties_gapcontinue(None),
+                                             mocked_request_properties_once(None)])
+    def test_list_properties_gapcontinue(self, mock_get):
+        result = self.mocked_wbengine.listProperties()
+        expected = ["Ensembl transcript ID", "chromosome", "genomic start", "instance of"]
+        self.assertListEqual(result, expected)
+
+    def test_get_namespace(self):
+        pass
+
+    def test_extract_properties(self):
+        properties = []
+        wbs_core.WikibaseEngine.extractProperties(self.model, properties)
+        expected = []
+        self.assertListEqual(properties, expected)
+
+    def _load_test_shex(self, file_name):
+        with open(os.path.join(TEST_DATA_DIR, file_name), 'r', encoding='utf-8') as f:
+            shex = f.read()
+            loader = SchemaLoader()
+            schema = loader.loads(shex)
+            self.model = json.loads(schema._as_json_dumps())


### PR DESCRIPTION
The following functionality was added to the wbs_core module:
* Fixed an error when trying to copy properties to an empty wikibase instance. Now when the listProperties method of the WikibaseEngine is called, an empty list is returned when the target wikibase is empty:
```python
def listProperties(self):
    if 'query' not in properties:
        # wikibase is empty
        return []
    ...
```
* Now the listProperties method returns the complete list of properties of the wikibase using the 'continue' param when needed, instead of just returning the last 10. This fixes an error when sometimes a property that already exists in the target wikibase was trying to be created again.
* The listProperties method is just called once when creating a new property, improving the performance when copying properties.
* Added tests for some of the methods of the module.
* Added docstrings for the copyProperties and listProperties methods.