### PR TITLE
Add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(
         'requests',
         'python-dateutil',
         'simplejson',
+        'pandas',
+        'tqdm',
         'mwoauth',
         'oauthlib',
         'sparql_slurper',


### PR DESCRIPTION
These two dependencies are present in requirements.txt. However, they are missing in setup.py and the sample bot code fails telling that pandas and tqdm are missing.