### PR TITLE
Enable creation of the Publication by arXiv identifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,10 @@
 long_description = file: README.md
 long_description_content_type = text/markdown
 
+[options.entry_points]
+console_scripts =
+    wikidataintegrator-publication = wikidataintegrator.wdi_helpers.publication:main
+
 [check-manifest]
 ignore =
     .travis.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
-description-file = README.md
+long_description = file: README.md
+long_description_content_type = text/markdown
 
 [check-manifest]
 ignore =

--- a/wikidataintegrator/wdi_helpers/__init__.py
+++ b/wikidataintegrator/wdi_helpers/__init__.py
@@ -42,7 +42,8 @@ PROPS = {
     'orcid id': "P496",
     'stated in': "P248",
     'retrieved': 'P813',
-    'mapping relation type': 'P4390'
+    'mapping relation type': 'P4390',
+    'arxiv id': 'P818',
 }
 
 # https://www.wikidata.org/wiki/Property:P4390

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -486,7 +486,9 @@ if __name__ == "__main__":
             WDUSER = os.environ['WDUSER']
             WDPASS = os.environ['WDPASS']
         else:
-            raise ValueError("WDUSER and WDPASS must be specified in local.py or as environment variables")
+            import getpass
+            WDUSER = input('Wikidata Username: ')
+            WDPASS = getpass.getpass('Wikidata Password: ')
 
     parser = argparse.ArgumentParser(description='run publication creator')
     parser.add_argument("ext_id", help="comma-separated list of IDs")

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -36,7 +36,7 @@ class Publication:
         'europepmc': 'Q5412157'
     }
 
-    def __init__(self, title=None, instance_of=None, subtitle=None, authors=list(),
+    def __init__(self, title=None, instance_of=None, subtitle=None, authors=None,
                  publication_date=None, original_language_of_work=None,
                  published_in_issn=None, published_in_isbn=None,
                  volume=None, issue=None, pages=None, number_of_pages=None, cites=None,
@@ -52,7 +52,7 @@ class Publication:
         :param authors: authors is a list of dicts, containing the following keys: full_name, orcid (optional)
                 example: {'full_name': "Andrew I. Su", 'orcid': "0000-0002-9859-4104"}
                 If author name can't be parsed, use value None. i.e. {'full_name': None}
-        :type authors: list
+        :type authors: Optional[list]
         :param publication_date:
         :type publication_date: datetime.datetime
         :param published_in_issn: The issn# for the journal
@@ -86,6 +86,9 @@ class Publication:
         :param sponsor: Not implemented
         :param data_available_at: Not implemented
         """
+        if authors is None:
+            authors = []
+
         # Input is an API agnostic representation of a publication
         self.warnings = []
         self._instance_of = instance_of

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -23,17 +23,20 @@ class Publication:
     ID_TYPES = {
         "doi": "P356",
         "pmid": "P698",
-        "pmcid": "P932"
+        "pmcid": "P932",
+        'arxiv': 'P818',
     }
 
     INSTANCE_OF = {
         "scientific_article": "Q13442814",
-        "publication": "Q732577"
+        "publication": "Q732577",
+        'preprint': 'Q580922',
     }
 
     SOURCES = {
         'crossref': 'Q5188229',
-        'europepmc': 'Q5412157'
+        'europepmc': 'Q5412157',
+        'arxiv': 'Q118398',
     }
 
     def __init__(self, title=None, instance_of=None, subtitle=None, authors=None,
@@ -195,20 +198,22 @@ class Publication:
     def make_reference(self):
         if self.source == "crossref":
             assert 'doi' in self.ids
-            extid = wdi_core.WDString(self.ids['doi'], PROPS['DOI'], is_reference=True)
-            ref_url = wdi_core.WDUrl(self.ref_url, PROPS['reference URL'], is_reference=True)
-            stated_in = wdi_core.WDItemID(self.SOURCES[self.source], PROPS['stated in'], is_reference=True)
-            retrieved = wdi_core.WDTime(strftime("+%Y-%m-%dT00:00:00Z", gmtime()), PROPS['retrieved'],
-                                        is_reference=True)
-            self.reference = [stated_in, extid, ref_url, retrieved]
+            edt_id_id, ext_id_prop = self.ids['doi'], PROPS['DOI']
         elif self.source == "europepmc":
             assert 'pmcid' in self.ids
-            extid = wdi_core.WDString(self.ids['pmcid'], PROPS['PMCID'], is_reference=True)
-            ref_url = wdi_core.WDUrl(self.ref_url, PROPS['reference URL'], is_reference=True)
-            stated_in = wdi_core.WDItemID(self.SOURCES[self.source], PROPS['stated in'], is_reference=True)
-            retrieved = wdi_core.WDTime(strftime("+%Y-%m-%dT00:00:00Z", gmtime()), PROPS['retrieved'],
-                                        is_reference=True)
-            self.reference = [stated_in, extid, ref_url, retrieved]
+            edt_id_id, ext_id_prop = self.ids['pmcid'], PROPS['PMCID']
+        elif self.source == 'arxiv':
+            assert 'arxiv' in self.ids
+            edt_id_id, ext_id_prop = self.ids['arxiv'], PROPS['arxiv id']
+        else:
+            raise ValueError(f'Unhandled source: {self.source}')
+
+        extid = wdi_core.WDString(edt_id_id, ext_id_prop, is_reference=True)
+        ref_url = wdi_core.WDUrl(self.ref_url, PROPS['reference URL'], is_reference=True)
+        stated_in = wdi_core.WDItemID(self.SOURCES[self.source], PROPS['stated in'], is_reference=True)
+        retrieved = wdi_core.WDTime(strftime("+%Y-%m-%dT00:00:00Z", gmtime()), PROPS['retrieved'],
+                                    is_reference=True)
+        self.reference = [stated_in, extid, ref_url, retrieved]
 
     def set_label(self, item):
         # item is a WDItemEngine
@@ -228,6 +233,8 @@ class Publication:
             item.set_description("{}".format(self.instance_of.replace("_", " ")))
 
     def make_statements(self):
+        if self.instance_of_qid is None:
+            raise ValueError('can not create WDItemID with None')
         self.statements.append(
             wdi_core.WDItemID(self.instance_of_qid, PROPS['instance of'], references=[self.reference]))
         self.statements.append(wdi_core.WDMonolingualText(self.title, PROPS['title'], references=[self.reference]))
@@ -284,7 +291,10 @@ class Publication:
         self.set_label(item)
         self.set_description(item)
 
-        success = try_write(item, self.ids['doi'], PROPS["DOI"], login)
+        if self.source == 'arxiv':
+            success = try_write(item, self.ids['arxiv'], PROPS["arxiv id"], login)
+        else:
+            success = try_write(item, self.ids['doi'], PROPS["DOI"], login)
         return item.wd_item_id, self.warnings, success
 
 
@@ -437,10 +447,37 @@ def europepmc_api_to_publication(ext_id, id_type):
     return p
 
 
+
+def arxiv_api_to_publication(ext_id, id_type='arxiv'):
+    """Make a Publication from an arXiv identifier."""
+    from manubot.cite.arxiv import get_arxiv_csl_item
+    j = get_arxiv_csl_item(ext_id)
+
+    year, month, day = j['issued']['date-parts'][0]
+
+    publication = Publication(
+        title=j['title'],
+        ref_url=j['URL'],
+        authors=[
+            {
+                'full_name': f'{author["given"]} {author["family"]}',
+            }
+            for author in j['author']
+        ],
+        publication_date=datetime.datetime(year=year, month=month, day=day),
+        ids={'arxiv': ext_id},
+        source='arxiv',
+        full_work_available_at=f'https://arxiv.org/pdf/{ext_id}',
+    )
+    publication.instance_of = 'preprint'
+    return publication
+
+
 class PublicationHelper:
     SOURCE_FUNCT = {
         'crossref': crossref_api_to_publication,
         'europepmc': europepmc_api_to_publication,
+        'arxiv': arxiv_api_to_publication,
     }
 
     def __init__(self, ext_id, id_type, source):

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -515,7 +515,7 @@ class PublicationHelper:
             return None, [], self.e
 
 
-if __name__ == "__main__":
+def main():
     try:
         from local import WDUSER, WDPASS
     except ImportError:
@@ -550,3 +550,7 @@ if __name__ == "__main__":
             except Exception as e:
                 print("{},{},{},{}".format(ext_id, None, e, False))
                 print("{},{},{},{}".format(ext_id, None, e, False), file=f)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR mainly adds the function `wikidataintegrator.wdi_helpers.publication.arxiv_api_to_publication` and integrates it with the `wikidataintegrator.wdi_helpers.publication.Publication` class to allow specifying the source/idtype as `arxiv`. 

I ran the code

```sh
python -m wikidataintegrator.wdi_helpers.publication 2006.08589 --source arxiv --idtype arxiv
```

and was happy greeted by 
```
Successfully logged in as Cthoyt
2006.08589,Q96335314,,True
```

and my shiny new WikiData entry https://www.wikidata.org/wiki/Q96335314.

This PR adds a few minor tweaks as well:

- Enables specification of username/password from the CLI using `getpass` if it's not available in the environment or a local.py file
- Fixes unsafe usage of a mutable default argument for `authors` in `Publication.__init__`.
- Encapsulate CLI in `wikidataintegrator.wdi_helpers.publication` in `main()`
- Fix the definition of package metadata in `setup.cfg`
- Add vanity CLI, so you could run `wikidataintegrator-publication 2006.08589 --source arxiv --idtype arxiv` instead