### PR TITLE
Adding support for localMedia type

### DIFF
--- a/wikidataintegrator/wdi_core.py
+++ b/wikidataintegrator/wdi_core.py
@@ -2842,6 +2842,59 @@ class WDCommonsMedia(WDBaseDataType):
             return cls(value=None, prop_nr=jsn['property'], snak_type=jsn['snaktype'])
         return cls(value=jsn['datavalue']['value'], prop_nr=jsn['property'])
 
+class WDLocalMedia(WDBaseDataType):
+    """
+    Implements the data type for Wikibase local media files.
+    The new data type is introduced via the LocalMedia extension
+    https://github.com/ProfessionalWiki/WikibaseLocalMedia
+    """
+    DTYPE = 'localMedia'
+
+    def __init__(self, value, prop_nr, is_reference=False, is_qualifier=False, snak_type='value', references=None,
+                 qualifiers=None, rank='normal', check_qualifier_equality=True):
+        """
+        Constructor, calls the superclass WDBaseDataType
+        :param value: The media file name from the local Mediawiki to be used as the value
+        :type value: str
+        :param prop_nr: The property id for this claim
+        :type prop_nr: str with a 'P' prefix followed by digits
+        :param is_reference: Whether this snak is a reference
+        :type is_reference: boolean
+        :param is_qualifier: Whether this snak is a qualifier
+        :type is_qualifier: boolean
+        :param snak_type: The snak type, either 'value', 'somevalue' or 'novalue'
+        :type snak_type: str
+        :param references: List with reference objects
+        :type references: A WD data type with subclass of WDBaseDataType
+        :param qualifiers: List with qualifier objects
+        :type qualifiers: A WD data type with subclass of WDBaseDataType
+        :param rank: WD rank of a snak with value 'preferred', 'normal' or 'deprecated'
+        :type rank: str
+        """
+
+        super(WDLocalMedia, self).__init__(value=value, snak_type=snak_type, data_type=self.DTYPE,
+                                           is_reference=is_reference, is_qualifier=is_qualifier,
+                                           references=references, qualifiers=qualifiers, rank=rank, prop_nr=prop_nr,
+                                           check_qualifier_equality=check_qualifier_equality)
+
+        self.set_value(value)
+
+    def set_value(self, value):
+        assert isinstance(value, str) or value is None, "Expected str, found {} ({})".format(type(value), value)
+        self.json_representation['datavalue'] = {
+            'value': value,
+            'type': 'string'
+        }
+
+        super(WDLocalMedia, self).set_value(value)
+
+    @classmethod
+    @JsonParser
+    def from_json(cls, jsn):
+        if jsn['snaktype'] == 'novalue' or jsn['snaktype'] == 'somevalue':
+            return cls(value=None, prop_nr=jsn['property'], snak_type=jsn['snaktype'])
+        return cls(value=jsn['datavalue']['value'], prop_nr=jsn['property'])
+
 
 class WDGlobeCoordinate(WDBaseDataType):
     """


### PR DESCRIPTION
Rhizome is using the [Wikibase extension for local media files](https://github.com/ProfessionalWiki/WikibaseLocalMedia) in addition to commons media files. This pull request adds support for that type, without affecting any other data type. I mainly copied the `WDCommonsMedia` class and edited a few places.