### PR TITLE
Add bioRxiv publications

### DIFF
--- a/wikidataintegrator/wdi_helpers/__init__.py
+++ b/wikidataintegrator/wdi_helpers/__init__.py
@@ -44,7 +44,6 @@ PROPS = {
     'retrieved': 'P813',
     'mapping relation type': 'P4390',
     'arxiv id': 'P818',
-    'biorxiv id': 'P3951',
 }
 
 # https://www.wikidata.org/wiki/Property:P4390

--- a/wikidataintegrator/wdi_helpers/__init__.py
+++ b/wikidataintegrator/wdi_helpers/__init__.py
@@ -44,6 +44,7 @@ PROPS = {
     'retrieved': 'P813',
     'mapping relation type': 'P4390',
     'arxiv id': 'P818',
+    'biorxiv id': 'P3951',
 }
 
 # https://www.wikidata.org/wiki/Property:P4390

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -25,7 +25,7 @@ class Publication:
         "pmid": "P698",
         "pmcid": "P932",
         'arxiv': 'P818',
-        'biorxiv': 'P3951',
+        'biorxiv': PROPS['biorxiv id'],
     }
 
     INSTANCE_OF = {

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -509,9 +509,9 @@ def arxiv_api_to_publication(ext_id, id_type='arxiv'):
     return publication
 
 
-def biorxiv_api_to_publication(ext_id, id_type='biorxiv'):
+def biorxiv_api_to_publication(biorxiv_id: str, id_type='biorxiv') -> Publication:
     """Make a :class:`Publication` from a bioRxiv identifier."""
-    url = f'https://api.biorxiv.org/details/biorxiv/10.1101/{ext_id}'
+    url = f'https://api.biorxiv.org/details/biorxiv/10.1101/{biorxiv_id}'
     headers = {
         'User-Agent': config['USER_AGENT_DEFAULT']
     }
@@ -524,7 +524,7 @@ def biorxiv_api_to_publication(ext_id, id_type='biorxiv'):
 
     publication = Publication(
         title=latest_revision['title'],
-        ref_url=f'https://www.biorxiv.org/content/10.1101/{ext_id}v{version}',
+        ref_url=f'https://www.biorxiv.org/content/10.1101/{biorxiv_id}v{version}',
         authors=[
             {
                 'full_name': author,
@@ -534,11 +534,11 @@ def biorxiv_api_to_publication(ext_id, id_type='biorxiv'):
         ],
         publication_date=datetime.datetime.strptime(latest_revision['date'], '%Y-%m-%d'),
         ids={
-            'biorxiv': ext_id,
+            'biorxiv': biorxiv_id,
             'doi': latest_revision['doi'],
         },
         source='biorxiv',
-        full_work_available_at=f'https://www.biorxiv.org/content/10.1101/{ext_id}v{version}.full.pdf',
+        full_work_available_at=f'https://www.biorxiv.org/content/10.1101/{biorxiv_id}v{version}.full.pdf',
     )
     publication.instance_of = 'preprint'
     return publication

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -596,17 +596,8 @@ def main():
             WDUSER = os.environ['WDUSER']
             WDPASS = os.environ['WDPASS']
         else:
-            try:
-                import pystow
-            except ImportError:
-                WDUSER, WDPASS = None, None
-            else:
-                WDUSER = pystow.get_config('wikidata', 'username')
-                WDPASS = pystow.get_config('wikidata', 'password')
-        if not WDUSER:
-            WDUSER = input('Wikidata Username: ')
-        if not WDPASS:
             import getpass
+            WDUSER = input('Wikidata Username: ')
             WDPASS = getpass.getpass('Wikidata Password: ')
 
     parser = argparse.ArgumentParser(description='run publication creator')

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -555,8 +555,17 @@ def main():
             WDUSER = os.environ['WDUSER']
             WDPASS = os.environ['WDPASS']
         else:
-            import getpass
+            try:
+                import pystow
+            except ImportError:
+                WDUSER, WDPASS = None, None
+            else:
+                WDUSER = pystow.get_config('wikidata', 'username')
+                WDPASS = pystow.get_config('wikidata', 'password')
+        if not WDUSER:
             WDUSER = input('Wikidata Username: ')
+        if not WDPASS:
+            import getpass
             WDPASS = getpass.getpass('Wikidata Password: ')
 
     parser = argparse.ArgumentParser(description='run publication creator')

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -25,7 +25,7 @@ class Publication:
         "pmid": "P698",
         "pmcid": "P932",
         'arxiv': 'P818',
-        'biorxiv': PROPS['biorxiv id'],
+        'biorxiv': 'P3951',
     }
 
     INSTANCE_OF = {
@@ -209,7 +209,7 @@ class Publication:
             edt_id_id, ext_id_prop = self.ids['arxiv'], PROPS['arxiv id']
         elif self.source == 'biorxiv':
             assert 'biorxiv' in self.ids
-            edt_id_id, ext_id_prop = self.ids['biorxiv'], PROPS['biorxiv id']
+            edt_id_id, ext_id_prop = self.ids['biorxiv'], self.ID_TYPES['biorxiv']
         else:
             raise ValueError(f'Unhandled source: {self.source}')
 

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -519,7 +519,7 @@ def biorxiv_api_to_publication(ext_id, id_type='biorxiv'):
     response.raise_for_status()
     revisions = response.json()['collection']
     latest_revision = revisions[-1]
-    version = len(revisions)
+    version = latest_revision['version']
     authors = [author.strip() for author in latest_revision['authors'].split(';')]
 
     publication = Publication(

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -506,6 +506,7 @@ def arxiv_api_to_publication(ext_id, id_type='arxiv'):
         full_work_available_at=f'https://arxiv.org/pdf/{ext_id}',
     )
     publication.instance_of = 'preprint'
+    publication.published_in_qid = Publication.SOURCES['arxiv']
     return publication
 
 
@@ -541,6 +542,7 @@ def biorxiv_api_to_publication(biorxiv_id: str, id_type='biorxiv') -> Publicatio
         full_work_available_at=f'https://www.biorxiv.org/content/10.1101/{biorxiv_id}v{version}.full.pdf',
     )
     publication.instance_of = 'preprint'
+    publication.published_in_qid = Publication.SOURCES['biorxiv']
     return publication
 
 

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -208,7 +208,6 @@ class Publication:
             assert 'arxiv' in self.ids
             edt_id_id, ext_id_prop = self.ids['arxiv'], PROPS['arxiv id']
         elif self.source == 'biorxiv':
-            assert 'biorxiv' in self.ids
             edt_id_id, ext_id_prop = self.ids['biorxiv'], self.ID_TYPES['biorxiv']
         else:
             raise ValueError(f'Unhandled source: {self.source}')

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -297,6 +297,8 @@ class Publication:
 
         if self.source == 'arxiv':
             success = try_write(item, self.ids['arxiv'], PROPS["arxiv id"], login)
+        elif self.source == 'biorxiv':
+            success = try_write(item, self.ids['biorxiv'], PROPS["biorxiv id"], login)
         else:
             success = try_write(item, self.ids['doi'], PROPS["DOI"], login)
         return item.wd_item_id, self.warnings, success


### PR DESCRIPTION
Similarly to #140, this PR enables the creation of new items based on bioRxiv identifiers.

DOIs can be automatically constructed from a bioRxiv identifier, and using the information from the API, the correct version-specific strings can also be constructed.

Demonstration: `biorxiv:804294` (https://www.biorxiv.org/content/10.1101/804294v3) can be seen at https://www.wikidata.org/wiki/Q104849590

Example CLI usage: `wikidataintegrator-publication --source biorxiv --idtype biorxiv 804294`