### PR TITLE
Add ChemRxiv publications

### DIFF
--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -552,8 +552,7 @@ def biorxiv_api_to_publication(biorxiv_id: str, id_type='biorxiv') -> Publicatio
 
 
 def chemrxiv_api_to_publication(chemrxiv_id: str, id_type='chemrxiv') -> Publication:
-    """Make a :class:`Publication` from a bioRxiv identifier."""
-    # https://doi.org/10.26434/chemrxiv.13607438.v1
+    """Make a :class:`Publication` from a ChemRxiv identifier."""
     url = f'https://api.figshare.com/v2/articles/{chemrxiv_id}'
     headers = {
         'User-Agent': config['USER_AGENT_DEFAULT']

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -210,6 +210,8 @@ class Publication:
             edt_id_id, ext_id_prop = self.ids['arxiv'], PROPS['arxiv id']
         elif self.source == 'biorxiv':
             edt_id_id, ext_id_prop = self.ids['biorxiv'], self.ID_TYPES['biorxiv']
+        elif self.source == 'chemrxiv':
+            edt_id_id, ext_id_prop = self.ids['doi'], self.ID_TYPES['doi']
         else:
             raise ValueError(f'Unhandled source: {self.source}')
 

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -560,20 +560,18 @@ def chemrxiv_api_to_publication(chemrxiv_id: str, id_type='chemrxiv') -> Publica
     }
     res = requests.get(url, headers=headers)
     res.raise_for_status()
-
     res_json = res.json()
-
-    authors = []
-    for author in res_json['authors']:
-        ad = {'full_name': author['full_name']}
-        if 'orcid_id' in author:
-            ad['orcid'] = author['orcid_id']
-        authors.append(ad)
 
     publication = Publication(
         title=res_json['title'],
         ref_url=res_json['figshare_url'],
-        authors=authors,
+        authors=[
+            {
+                'full_name': author['full_name'],
+                'orcid': author.get('orcid_id'),
+            }
+            for author in res_json['authors']
+        ],
         publication_date=datetime.datetime.strptime(res_json['published_date'], '%Y-%m-%dT%H:%M:%SZ'),
         ids={
             'doi': res_json['doi'],

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -39,6 +39,7 @@ class Publication:
         'europepmc': 'Q5412157',
         'arxiv': 'Q118398',
         'biorxiv': 'Q19835482',
+        'chemrxiv': 'Q50012382',
     }
 
     def __init__(self, title=None, instance_of=None, subtitle=None, authors=None,


### PR DESCRIPTION
Similarly to #140 and #169, this PR enables the creation of new items based on ChemRxiv identifiers. Unlike bioRxiv and arXiv, ChemRxiv does not have a property in Wikidata, but does issue DOIs.

Demonstration: `chemrxiv:13607438` (https://chemrxiv.org/articles/preprint/Enantioselective_Conjugate_Addition_of_Catalytically_Generated_Zinc_Homoenolate/13607438) can be seen at https://www.wikidata.org/wiki/Q104931192.

Example CLI usage: `wikidataintegrator-publication --source chemrxiv --idtype chemrxiv 804294`

Caveat: I'm not sure if the author ORCID identifier intake works well

Update: I've made a [property proposal on Wikidata](https://www.wikidata.org/wiki/Wikidata:Property_proposal/ChemRxiv_ID) for a first class ChemRxiv ID. If this gets accepted, then I will send a follow-up pull request to change the primary key to using the ChemRxiv ID.