### PR TITLE
update a deprecated request for fetching a token

### DIFF
--- a/wikidataintegrator/wdi_login.py
+++ b/wikidataintegrator/wdi_login.py
@@ -125,14 +125,14 @@ class WDLogin(object):
             self.generate_edit_credentials()
         else:
             params = {
-                'action': 'login',
-                'lgname': user,
-                'lgpassword': pwd,
+                'action': 'query',
+                'meta': 'tokens',
+                'type': 'login',
                 'format': 'json'
             }
 
             # get login token
-            login_token = self.s.post(self.mediawiki_api_url, data=params).json()['login']['token']
+            login_token = self.s.get(self.mediawiki_api_url, params=params).json()['query']['tokens']['logintoken']
 
             # do the login using the login token
             params.update({'lgtoken': login_token})

--- a/wikidataintegrator/wdi_login.py
+++ b/wikidataintegrator/wdi_login.py
@@ -134,8 +134,14 @@ class WDLogin(object):
             # get login token
             login_token = self.s.get(self.mediawiki_api_url, params=params).json()['query']['tokens']['logintoken']
 
+            params = {
+                'action': 'login',
+                'lgname': user,
+                'lgpassword': pwd,
+                'lgtoken': login_token,
+                'format': 'json'
+            }
             # do the login using the login token
-            params.update({'lgtoken': login_token})
             r = self.s.post(self.mediawiki_api_url, data=params).json()
 
             if r['login']['result'] != 'Success':


### PR DESCRIPTION
The POST request for fetching a token sends a warning ```'warnings': {'main': {'*': 'Subscribe to the mediawiki-api-announce mailing list at <https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce> for notice of API deprecations and breaking changes.'},
  'login': {'*': 'Fetching a token via "action=login" is deprecated. Use "action=query&meta=tokens&type=login" instead.'}}```. Let's replace it with GET request to "action=query". This is in accordance with https://www.mediawiki.org/wiki/API:Login.