### PR TITLE
Fix missing blank line in docstring

### DIFF
--- a/wikidataintegrator/ref_handlers/update_retrieved_if_new_multiple_refs.py
+++ b/wikidataintegrator/ref_handlers/update_retrieved_if_new_multiple_refs.py
@@ -17,6 +17,7 @@ def update_retrieved_if_new_multiple_refs(olditem, newitem, days=180, retrieved_
     def is_equal_not_retrieved(oldref, newref):
         """
         Return True if the oldref == newref, NOT including any "retrieved" statements
+
         :param oldref:
         :param newref:
         :return:

--- a/wikidataintegrator/wdi_backoff.py
+++ b/wikidataintegrator/wdi_backoff.py
@@ -34,6 +34,7 @@ def check_json_decode_error(e):
     """
     Check if the error message is "Expecting value: line 1 column 1 (char 0)"
     if not, its a real error and we shouldn't retry
+
     :param e:
     :return:
     """

--- a/wikidataintegrator/wdi_core.py
+++ b/wikidataintegrator/wdi_core.py
@@ -161,6 +161,7 @@ class WDFunctionsEngine(object):
         """
         Takes a list of items and posts them for deletion by Wikidata moderators, appends at the end of the deletion
         request page.
+
         :param item: a QID which should be deleted
         :type item: string
         :param reason: short text about the reason for the deletion request
@@ -207,6 +208,7 @@ class WDFunctionsEngine(object):
     def check_shex_conformance(qid=None,data=None, eid=None, entity_schema_repo=None, output='confirm'):
         """
                 Static method which can be used to check for conformance of a Wikidata item to an EntitySchema any SPARQL query
+
                 :param qid: The URI prefixes required for an endpoint, default is the Wikidata specific prefixes
                 :param eid: The EntitySchema identifier from Wikidata
                 :param sparql_endpoint_url: The URL string for the SPARQL endpoint. Default is the URL for the Wikidata SPARQL endpoint
@@ -250,6 +252,7 @@ class WDFunctionsEngine(object):
         It extracts a shape tor the entity specified in qid. The shape is built w.r.t the outgoing
         properties of the selected Wikidata entity.
         Optionally, it generates as well a shape for each qualifier.
+
         :param qid: Wikidata identifier to which other wikidata items link
         :param extract_shape_of_qualifiers: It it is set to True, the result will contain the shape of the qid
                 selected but also the shapes of its qualifiers.
@@ -315,6 +318,7 @@ class WDItemEngine(object):
                  fast_run_case_insensitive=False, debug=False):
         """
         constructor
+
         :param wd_item_id: Wikidata item id
         :param new_item: This parameter lets the user indicate if a new item should be created
         :type new_item: True or False
@@ -581,6 +585,7 @@ class WDItemEngine(object):
     def get_wd_entity(self):
         """
         retrieve a WD item in json representation from Wikidata
+
         :rtype: dict
         :return: python complex dictionary represenation of a json
         """
@@ -599,6 +604,7 @@ class WDItemEngine(object):
     def parse_wd_json(self, wd_json):
         """
         Parses a WD entity json and generates the datatype objects, sets self.wd_json_representation
+
         :param wd_json: the json of a WD entity
         :type wd_json: A Python Json representation of a WD item
         :return: returns the json representation containing 'labels', 'descriptions', 'claims', 'aliases', 'sitelinks'.
@@ -628,6 +634,7 @@ class WDItemEngine(object):
                               language='en', dict_id_label=False, dict_id_all_info=False):
         """
         Performs a search in WD for a certain WD search string
+
         :param search_string: a string which should be searched for in WD
         :type search_string: str
         :param mediawiki_api_url: Specify the mediawiki_api_url.
@@ -696,6 +703,7 @@ class WDItemEngine(object):
     def get_property_list(self):
         """
         List of properties on the current item
+
         :return: a list of WD property ID strings (Pxxxx).
         """
         property_list = set()
@@ -707,6 +715,7 @@ class WDItemEngine(object):
     def __select_wd_item(self):
         """
         The most likely WD item QID should be returned, after querying WDQ for all values in core_id properties
+
         :return: Either a single WD QID is returned, or an empty string if no suitable item in WD
         """
         qid_list = set()
@@ -777,6 +786,7 @@ class WDItemEngine(object):
     def __construct_claim_json(self):
         """
         Writes the properties from self.data to a new or existing json in self.wd_json_representation
+
         :return: None
         """
 
@@ -839,6 +849,7 @@ class WDItemEngine(object):
         def handle_references(old_item, new_item):
             """
             Local function to handle references
+
             :param old_item: An item containing the data as currently in WD
             :type old_item: A child of WDBaseDataType
             :param new_item: An item containing the new data which should be written to WD
@@ -971,6 +982,7 @@ class WDItemEngine(object):
         allows for checking the item data before deciding which new data should be written to the Wikidata item.
         The actual write to Wikidata only happens on calling of the write() method. If data has been provided already
         via the constructor, data provided via the update() method will be appended to these data.
+
         :param data: A list of Wikidata statment items inheriting from WDBaseDataType
         :type data: list
         :param append_value: list with Wikidata property strings where the values should only be appended,
@@ -1003,6 +1015,7 @@ class WDItemEngine(object):
     def get_wd_json_representation(self):
         """
         A method to access the internal json representation of the WD item, mainly for testing
+
         :return: returns a Python json representation object of the WD item at the current state of the instance
         """
         return self.wd_json_representation
@@ -1013,6 +1026,7 @@ class WDItemEngine(object):
         has a property of the current domain with a value like submitted in the data dict, this item does not get
         selected but a ManualInterventionReqException() is raised. This check is dependent on the core identifiers
         of a certain domain.
+
         :return: boolean True if test passed
         """
         # all core props
@@ -1057,6 +1071,7 @@ class WDItemEngine(object):
     def get_pageid(self):
         """
         Returns the pageid of a Wikidata item
+
         :return:
         """
         return self.wd_json_representation['pageid']
@@ -1064,6 +1079,7 @@ class WDItemEngine(object):
     def get_label(self, lang='en'):
         """
         Returns the label for a certain language
+
         :param lang:
         :type lang: str
         :return: returns the label in the specified language, an empty string if the label does not exist
@@ -1078,6 +1094,7 @@ class WDItemEngine(object):
     def set_label(self, label, lang='en'):
         """
         Set the label for a WD item in a certain language
+
         :param label: The description of the item in a certain language
         :type label: str
         :param lang: The language a label should be set for.
@@ -1103,6 +1120,7 @@ class WDItemEngine(object):
     def get_aliases(self, lang='en'):
         """
         Retrieve the aliases in a certain language
+
         :param lang: The Wikidata language the description should be retrieved for
         :return: Returns a list of aliases, an empty list if none exist for the specified language
         """
@@ -1119,6 +1137,7 @@ class WDItemEngine(object):
     def set_aliases(self, aliases, lang='en', append=True):
         """
         set the aliases for a WD item
+
         :param aliases: a list of strings representing the aliases of a WD item
         :param lang: The language a description should be set for
         :param append: If true, append a new alias to the list of existing aliases, else, overwrite. Default: True
@@ -1157,6 +1176,7 @@ class WDItemEngine(object):
     def get_description(self, lang='en'):
         """
         Retrieve the description in a certain language
+
         :param lang: The Wikidata language the description should be retrieved for
         :return: Returns the description string
         """
@@ -1170,6 +1190,7 @@ class WDItemEngine(object):
     def set_description(self, description, lang='en'):
         """
         Set the description for a WD item in a certain language
+
         :param description: The description of the item in a certain language
         :type description: str
         :param lang: The language a description should be set for.
@@ -1195,6 +1216,7 @@ class WDItemEngine(object):
     def set_sitelink(self, site, title, badges=()):
         """
         Set sitelinks to corresponding Wikipedia pages
+
         :param site: The Wikipedia page a sitelink is directed to (e.g. 'enwiki')
         :param title: The title of the Wikipedia page the sitelink is directed to
         :param badges: An iterable containing Wikipedia badge strings.
@@ -1211,6 +1233,7 @@ class WDItemEngine(object):
     def get_sitelink(self, site):
         """
         A method to access the interwiki links in the json.model
+
         :param site: The Wikipedia site the interwiki/sitelink should be returned for
         :return: The interwiki/sitelink string for the specified Wikipedia will be returned.
         """
@@ -1224,6 +1247,7 @@ class WDItemEngine(object):
         """
         Writes the WD item Json to WD and after successful write, updates the object with new ids and hashes generated
         by WD. For new items, also returns the new QIDs.
+
         :param login: a instance of the class PBB_login which provides edit-cookies and edit-tokens
         :param bot_account: Tell the Wikidata API whether the script should be run as part of a bot account or not.
         :type bot_account: bool
@@ -1376,6 +1400,7 @@ class WDItemEngine(object):
                       delimiter=";", logger_name='WD_logger'):
         """
         A static method which initiates log files compatible to .csv format, allowing for easy further analysis.
+
         :param log_dir: allows for setting relative or absolute path for logging, default is ./logs.
         :type log_dir: str
         :param log_name: File name of log file to be written. e.g. "WD_bot_run-20160204.log". Default is "WD_bot_run"
@@ -1450,6 +1475,7 @@ class WDItemEngine(object):
         A method which allows for retrieval of a list of Wikidata items or properties. The method generates a list of
         tuples where the first value in the tuple is the QID or property ID, whereas the second is the new instance of
         WDItemEngine containing all the data of the item. This is most useful for mass retrieval of WD items.
+
         :param items: A list of QIDs or property IDs
         :type items: list
         :param mediawiki_api_url: The MediaWiki url which should be used
@@ -1495,6 +1521,7 @@ class WDItemEngine(object):
                              user_agent=None, as_dataframe=False, max_retries=1000, retry_after=60):
         """
         Static method which can be used to execute any SPARQL query
+
         :param prefix: The URI prefixes required for an endpoint, default is the Wikidata specific prefixes
         :param query: The actual SPARQL query string
         :param endpoint: The URL string for the SPARQL endpoint. Default is the URL for the Wikidata SPARQL endpoint
@@ -1610,6 +1637,7 @@ class WDItemEngine(object):
                     ignore_conflicts='', user_agent=None):
         """
         A static method to merge two Wikidata items
+
         :param from_id: The QID which should be merged into another item
         :type from_id: string with 'Q' prefix
         :param to_id: The QID into which another item should be merged
@@ -1685,6 +1713,7 @@ class WDItemEngine(object):
         """
         Takes a list of items and posts them for deletion by Wikidata moderators, appends at the end of the deletion
         request page.
+
         :param item: a QID which should be deleted
         :type item: string
         :param reason: short text about the reason for the deletion request
@@ -1756,6 +1785,7 @@ class WDItemEngine(object):
         """
         Helper function for creating a WDItemEngine class with arguments set for a different Wikibase instance than
         Wikidata.
+
         :param mediawiki_api_url: Mediawiki api url. For wikidata, this is: 'https://www.wikidata.org/w/api.php'
         :param sparql_endpoint_url: sparql endpoint url. For wikidata, this is: 'https://query.wikidata.org/sparql'
         :param name: name of the resulting class
@@ -1889,6 +1919,7 @@ class WDBaseDataType(object):
                  check_qualifier_equality):
         """
         Constructor, will be called by all data types.
+
         :param value: Data value of the WD data snak
         :type value: str or int or tuple
         :param snak_type: The snak type of the WD data snak, three values possible, depending if the value is a
@@ -2170,6 +2201,7 @@ class WDBaseDataType(object):
         This serves as an alternative constructor for WDBaseDataType with the only purpose of holding a WD property
         number and an empty string value in order to indicate that the whole statement with this property number of a
         WD item should be deleted.
+
         :param prop_nr: A WD property number as string
         :return: An instance of WDBaseDataType
         """
@@ -2230,6 +2262,7 @@ class WDString(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The string to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2284,6 +2317,7 @@ class WDMath(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The string to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2337,6 +2371,7 @@ class WDExternalID(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The string to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2403,6 +2438,7 @@ class WDItemID(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The WD item ID to serve as the value
         :type value: str with a 'Q' prefix, followed by several digits or only the digits without the 'Q' prefix
         :param prop_nr: The WD item ID for this claim
@@ -2487,6 +2523,7 @@ class WDProperty(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The WD property number to serve as a value
         :type value: str with a 'P' prefix, followed by several digits or only the digits without the 'P' prefix
         :param prop_nr: The WD property number for this claim
@@ -2560,6 +2597,7 @@ class WDTime(WDBaseDataType):
                  references=None, qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param time: A time representation string in the following format: '+%Y-%m-%dT%H:%M:%SZ'
         :type time: str in the format '+%Y-%m-%dT%H:%M:%SZ', e.g. '+2001-12-31T12:01:13Z'
         :param prop_nr: The WD property number for this claim
@@ -2645,6 +2683,7 @@ class WDUrl(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The URL to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2705,6 +2744,7 @@ class WDMonolingualText(WDBaseDataType):
                  references=None, qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The language specific string to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2769,6 +2809,7 @@ class WDQuantity(WDBaseDataType):
                  check_qualifier_equality=True, concept_base_uri=None):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The quantity value
         :type value: float, str
         :param prop_nr: The WD item ID for this claim
@@ -2890,6 +2931,7 @@ class WDCommonsMedia(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The media file name from Wikimedia commons to be used as the value
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -2943,6 +2985,7 @@ class WDLocalMedia(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The media file name from the local Mediawiki to be used as the value
         :type value: str
         :param prop_nr: The property id for this claim
@@ -2996,6 +3039,7 @@ class WDGlobeCoordinate(WDBaseDataType):
                  snak_type='value', references=None, qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param latitude: Latitute in decimal format
         :type latitude: float
         :param longitude: Longitude in decimal format
@@ -3074,6 +3118,7 @@ class WDGeoShape(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The GeoShape map file name in Wikimedia Commons to be linked
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -3135,6 +3180,7 @@ class WDMusicalNotation(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: Values for that data type are strings describing music following LilyPond syntax.
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -3190,6 +3236,7 @@ class WDTabularData(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: Reference to tabular data file on Wikimedia Commons.
         :type value: str
         :param prop_nr: The WD item ID for this claim
@@ -3264,6 +3311,7 @@ class WDLexeme(WDBaseDataType):
 
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The WD lexeme number to serve as a value
         :type value: str with a 'P' prefix, followed by several digits or only the digits without the 'P' prefix
         :param prop_nr: The WD property number for this claim
@@ -3336,6 +3384,7 @@ class WDForm(WDBaseDataType):
                  qualifiers=None, rank='normal', check_qualifier_equality=True):
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The WD form number to serve as a value using the format "L<Lexeme ID>-F<Form ID>" (example: L252248-F2)
         :type value: str with a 'P' prefix, followed by several digits or only the digits without the 'P' prefix
         :param prop_nr: The WD property number for this claim
@@ -3403,6 +3452,7 @@ class WDSense(WDBaseDataType):
 
         """
         Constructor, calls the superclass WDBaseDataType
+
         :param value: The WD form number to serve as a value using the format "L<Lexeme ID>-F<Form ID>" (example: L252248-F2)
         :type value: str with a 'P' prefix, followed by several digits or only the digits without the 'P' prefix
         :param prop_nr: The WD property number for this claim

--- a/wikidataintegrator/wdi_fastrun.py
+++ b/wikidataintegrator/wdi_fastrun.py
@@ -263,6 +263,7 @@ class FastRunContainer(object):
     def init_language_data(self, lang, lang_data_type):
         """
         Initialize language data store
+
         :param lang: language code
         :param lang_data_type: 'label', 'description' or 'aliases'
         :return: None
@@ -278,6 +279,7 @@ class FastRunContainer(object):
     def get_language_data(self, qid, lang, lang_data_type):
         """
         get language data for specified qid
+
         :param qid:
         :param lang: language code
         :param lang_data_type: 'label', 'description' or 'aliases'
@@ -298,6 +300,7 @@ class FastRunContainer(object):
     def check_language_data(self, qid, lang_data, lang, lang_data_type):
         """
         Method to check if certain language data exists as a label, description or aliases
+
         :param lang_data: list of string values to check
         :type lang_data: list
         :param lang: language code

--- a/wikidataintegrator/wdi_helpers/__init__.py
+++ b/wikidataintegrator/wdi_helpers/__init__.py
@@ -105,6 +105,7 @@ def try_write(wd_item, record_id, record_prop, login, edit_summary='', write=Tru
 def format_msg(external_id, external_id_prop, wdid, msg, msg_type=None, delimiter=";"):
     """
     Format message for logging
+
     :return: str
     """
     fmt = ('{}' + delimiter) * 4 + '{}'  # '{};{};{};{};{}'
@@ -128,6 +129,7 @@ def prop2qid(prop, value, endpoint='https://query.wikidata.org/sparql'):
     Lookup a wikidata item ID from a property and string value. For example, get the item QID for the
      item with the entrez gene id (P351): "899959"
     >>> prop2qid('P351','899959')
+
     :param prop: property
     :type prop: str
     :param value: value of property
@@ -156,6 +158,7 @@ def id_mapper(prop, filters=None, raise_on_duplicate=False, return_as_set=False,
                                      'Q53WF2': 'Q21766762', .... }
     Optional filters can filter query results.
     Example (get all uniprot to wdid, where taxon is human): id_mapper("P352",(("P703", "Q15978631"),))
+
     :param prop: wikidata property
     :type prop: str
     :param filters: list of tuples, where the first item is a property, second is a value
@@ -244,6 +247,7 @@ def get_values(pid, values, endpoint='https://query.wikidata.org/sparql'):
     """
     This is a basic version of id_mapper, but restrict to values in `values`.
     Missing IDs are ignored
+
     :param pid: PID
     :param values: list of strings
     :param endpoint: sparql endpoint url

--- a/wikidataintegrator/wdi_helpers/mapping_relation_helper.py
+++ b/wikidataintegrator/wdi_helpers/mapping_relation_helper.py
@@ -34,6 +34,7 @@ class MappingRelationHelper:
         """
         accepts a statement and adds a qualifer setting the mrt
         modifies s in place
+
         :param s: a WDBaseDataType statement
         :param mrt: one of {'close', 'broad', 'exact', 'related', 'narrow'}
         :return: s

--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -595,6 +595,7 @@ class PublicationHelper:
         """
         PublicationHelper: Helper to create wikidata items about literature
         Supported data sources and (ID types): crossref (doi), europepmc (pmid, pmcid, doi)
+
         :param ext_id: the external ID to use
         :type ext_id: str
         :param id_type: one of {'pmid', 'pmcid', 'doi'}
@@ -614,6 +615,7 @@ class PublicationHelper:
     def get_or_create(self, login):
         """
         Get the qid of the item by its external id or create if doesn't exist
+
         :param login: WDLogin item
         :return: tuple of (qid, list of warnings (strings), success (True if success, returns the Exception otherwise))
         """

--- a/wikidataintegrator/wdi_helpers/wikibase_helper.py
+++ b/wikidataintegrator/wdi_helpers/wikibase_helper.py
@@ -75,6 +75,7 @@ class WikibaseHelper:
         Example: In my wikibase, I have CDK2 (Q79363) with the only statement:
             equivalent class -> http://www.wikidata.org/entity/Q14911732
             Calling prop2qid("P351", "1017") will return the local QID (Q79363)
+
         :param prop:
         :param value:
         :return:

--- a/wikidataintegrator/wdi_login.py
+++ b/wikidataintegrator/wdi_login.py
@@ -28,6 +28,7 @@ class WDLogin(object):
         """
         This class handles several types of login procedures. Either use user and pwd authentication or OAuth.
         Wikidata clientlogin can also be used. If using one method, do NOT pass parameters for another method.
+
         :param user: the username which should be used for the login
         :param pwd: the password which should be used for the login
         :param token_renew_period: Seconds after which a new token should be requested from the Wikidata server
@@ -157,6 +158,7 @@ class WDLogin(object):
     def generate_edit_credentials(self):
         """
         request an edit token and update the cookie_jar in order to add the session cookie
+
         :return: Returns a json with all relevant cookies, aka cookie jar
         """
         params = {
@@ -172,6 +174,7 @@ class WDLogin(object):
     def generate_rollback_credentials(self):
         """
         request an edit token and update the cookie_jar in order to add the session cookie
+
         :return: Returns a json with all relevant cookies, aka cookie jar
         """
         params = {
@@ -188,6 +191,7 @@ class WDLogin(object):
     def get_edit_cookie(self):
         """
         Can be called in order to retrieve the cookies from an instance of WDLogin
+
         :return: Returns a json with all relevant cookies, aka cookie jar
         """
         if (time.time() - self.instantiation_time) > self.token_renew_period:
@@ -199,6 +203,7 @@ class WDLogin(object):
     def get_edit_token(self):
         """
         Can be called in order to retrieve the edit token from an instance of WDLogin
+
         :return: returns the edit token
         """
         if not self.edit_token or (time.time() - self.instantiation_time) > self.token_renew_period:
@@ -210,6 +215,7 @@ class WDLogin(object):
     def get_rollback_token(self):
         """
         Can be called in order to retrieve the edit token from an instance of WDLogin
+
         :return: returns the edit token
         """
         if not self.rollback_token or (time.time() - self.instantiation_time) > self.token_renew_period:
@@ -221,6 +227,7 @@ class WDLogin(object):
     def get_session(self):
         """
         returns the requests session object used for the login.
+
         :return: Object of type requests.Session()
         """
         return self.s
@@ -229,6 +236,7 @@ class WDLogin(object):
         """
         Continuation of OAuth procedure. Method must be explicitly called in order to complete OAuth. This allows
         external entities, e.g. websites, to provide tokens through callback URLs directly.
+
         :param oauth_callback_data: The callback URL received to a Web app
         :type oauth_callback_data: bytes
         :return:


### PR DESCRIPTION
Insert blank line before the first field (e.g. `:param:` `:return:`) of each docstring so that Sphinx can parse them correctly