### PR TITLE
fix: Fix value-type for edtf data-type

### DIFF
--- a/wikidataintegrator/wdi_core.py
+++ b/wikidataintegrator/wdi_core.py
@@ -2436,7 +2436,7 @@ class WDEDTF(WDBaseDataType):
 
         self.json_representation['datavalue'] = {
             'value': self.value,
-            'type': self.DTYPE
+            'type': 'string'
         }
 
         super(WDEDTF, self).set_value(value=self.value)


### PR DESCRIPTION
While the data-type for WDEDTF is indeed edtf, it's value-type is simply "string" as defined
here: https://github.com/ProfessionalWiki/WikibaseEdtf/blob/master/src/HookHandlers.php#L20

Without this fix, we'll have the API complain with an error such as this:

```json
{'error': {'code': 'modification-failed', 'info': 'Data value corrupt: Type "edtf" is unsupported', 'messages': [{'name': 'wikibase-validator-bad-value', 'parameters': ['Type "edtf" is unsupported'], 'html': {'*': 'Data value corrupt: Type "edtf" is unsupported'}}], '*': 'See http://localhost:8080/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce&gt; for notice of API deprecations and breaking changes.'}}
```
