### PR TITLE
change URL for Crossref API in wikidataintegrator/wdi_helpers/publication.py

### DIFF
--- a/wikidataintegrator/wdi_helpers/publication.py
+++ b/wikidataintegrator/wdi_helpers/publication.py
@@ -309,7 +309,7 @@ class Publication:
 
 def crossref_api_to_publication(ext_id, id_type="doi"):
     assert id_type == "doi", "Unsupported id type in crossref: {}".format(id_type)
-    url = "https://api.crossref.org/v1/works/http://dx.doi.org/{}"
+    url = "https://api.crossref.org/v1/works/https://doi.org/{}"
     url = url.format(ext_id)
 
     response = requests.get(url)


### PR DESCRIPTION
According to the [DOI Handbook](https://www.doi.org/doi_handbook/3_Resolution.html#3.7.3):

> https://doi.org is preferred, but the earlier syntax dx.doi.org remains fully supported