### PR TITLE
fix(wdi_login): Remove byte-encoding from split

### DIFF
--- a/wikidataintegrator/wdi_login.py
+++ b/wikidataintegrator/wdi_login.py
@@ -248,7 +248,7 @@ class WDLogin(object):
             self.response_qs = input("Callback URL: ")
 
         # input the url from redirect after authorization
-        response_qs = self.response_qs.split(b'?')[-1]
+        response_qs = self.response_qs.split('?')[-1]
 
         # Step 3: Complete -- obtain authorized key/secret for "resource owner"
         access_token = self.handshaker.complete(self.request_token, response_qs)


### PR DESCRIPTION
The question mark that is part of the oauth callback URL is not byte-encoded.
Keeping the byte-encoding mark in here leads to

```
    response_qs = self.response_qs.split(b'?')[-1]
TypeError: must be str or None, not bytes
```

This may differ per platform, but then maybe this PR will spark a discussion that has not yet been started from issue #181